### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
         mlat,skyfeed.hpradar.com,31090,39005;
         mlat,feed.radarplane.com,31090,39006;
         mlat,dati.flyitalyadsb.com,30100,39007;
-        mlathub,piaware,30104,beast_in;
+        mlathub,piaware,30105,beast_in;
         mlathub,rbfeeder,30105,beast_in;
         mlathub,radarvirtuel,30105,beast_in;
         mlathub,planewatch,30105,beast_in


### PR DESCRIPTION
Change piaware port in example compose from 30104 to 30105.
UF was not connecting to Piaware on 30104. Suggested change to 30105 via Johnex worked.
Other users also finding this a problem. 