### PR TITLE
Allow overriding the Prometheus port

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/prometheus-readsb
+++ b/rootfs/etc/s6-overlay/scripts/prometheus-readsb
@@ -9,7 +9,7 @@ if chk_enabled "$PROMETHEUS_ENABLE"; then
         sleep 1
     done
     trap "pkill -P $$ || true; s6wrap --timestamps --prepend=prometheus-readsb --quiet --args echo 'service stopping'; exit 0" SIGTERM SIGINT SIGHUP SIGQUIT
-    echo -e "HTTP/1.1 200 OK\nContent-Type: text/plain\n\n$(cat /run/readsb-prometheus.prom)" | ncat -l 9274 > /dev/null 2>&1 &
+    echo -e "HTTP/1.1 200 OK\nContent-Type: text/plain\n\n$(cat /run/readsb-prometheus.prom)" | ncat -l "${PROMETHEUSPORT:-9274}" > /dev/null 2>&1 &
     wait
 else
     exec sleep infinity


### PR DESCRIPTION
The docs suggest you can do this, but the code does not allow for it. This fixes that so you can specify your own port.

I've spotted an error in the docs too, MR for that repo will be along shortly.
