### PR TITLE
bugfix: fix s6wrap syntax error

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/mlat-client
+++ b/rootfs/etc/s6-overlay/scripts/mlat-client
@@ -218,9 +218,9 @@ do
         "${s6wrap[@]}" --prepend="$(basename "$0")][${servername}" --args echo "starting: ${MLAT_CMD} ${MLAT_PARAM[*]}"
         "${s6wrap[@]}" --prepend="$(basename "$0")][${servername}" --args ${execstring} &
     elif [[ "${LOGLEVEL,,}" == "error" ]]; then
-        "${s6wrap[@]}" --ignore-stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
+        "${s6wrap[@]}" --ignore=stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
     elif [[ "${LOGLEVEL,,}" == "none" ]]; then
-        "${s6wrap[@]}" --ignore-stderr --ignore-stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
+        "${s6wrap[@]}" --ignore=stderr --ignore=stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
     fi
 
     # pid_array is indexed by the PID of each mlat_client and contains the MLAT_PARAMs for that instance
@@ -254,9 +254,9 @@ do
             if [[ -z "${LOGLEVEL}" ]] || [[ "${LOGLEVEL,,}" == "verbose" ]]; then
                 "${s6wrap[@]}" --prepend="$(basename "$0")][${servername}" --args ${execstring} &
             elif [[ "${LOGLEVEL,,}" == "error" ]]; then
-                "${s6wrap[@]}" --ignore-stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
+                "${s6wrap[@]}" --ignore=stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
             elif [[ "${LOGLEVEL,,}" == "none" ]]; then
-                "${s6wrap[@]}" --ignore-stderr --ignore-stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
+                "${s6wrap[@]}" --ignore=stderr --ignore=stdout --prepend="$(basename "$0")][${servername}" --args ${execstring} &
             fi
 
             pid_array[$!]="${pid_array[${mlat_pid}]}"

--- a/rootfs/etc/s6-overlay/scripts/mlathub
+++ b/rootfs/etc/s6-overlay/scripts/mlathub
@@ -149,7 +149,7 @@ MLATHUB_CMD+=("--net-heartbeat=${READSB_NET_HEARTBEAT:-35}")
 if [[ -z "${LOGLEVEL}" ]] || [[ "${LOGLEVEL,,}" == "verbose" ]]; then
     exec "${s6wrap[@]}" --args "${MLATHUB_BIN}" "${MLATHUB_CMD[@]}" $MLATHUB_EXTRA_ARGS
 elif [[ "${LOGLEVEL,,}" == "error" ]]; then
-    exec "${s6wrap[@]}" --ignore-stdout --args "${MLATHUB_BIN}" "${MLATHUB_CMD[@]}" $MLATHUB_EXTRA_ARGS
+    exec "${s6wrap[@]}" --ignore=stdout --args "${MLATHUB_BIN}" "${MLATHUB_CMD[@]}" $MLATHUB_EXTRA_ARGS
 elif [[ "${LOGLEVEL,,}" == "none" ]]; then
-    exec "${s6wrap[@]}" --ignore-stdtout --ignore-stderr --args "${MLATHUB_BIN}" "${MLATHUB_CMD[@]}" $MLATHUB_EXTRA_ARGS
+    exec "${s6wrap[@]}" --ignore=stdtout --ignore=stderr --args "${MLATHUB_BIN}" "${MLATHUB_CMD[@]}" $MLATHUB_EXTRA_ARGS
 fi

--- a/rootfs/etc/s6-overlay/scripts/readsb
+++ b/rootfs/etc/s6-overlay/scripts/readsb
@@ -347,7 +347,7 @@ LOGLEVEL="${LOGLEVEL:-verbose}"
 if [[ "${LOGLEVEL,,}" == "verbose" ]]; then
     exec "${s6wrap[@]}" --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS
 elif [[ "${LOGLEVEL,,}" == "error" ]]; then
-    exec "${s6wrap[@]}" --ignore-stdout --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS
+    exec "${s6wrap[@]}" --ignore=stdout --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS
 elif [[ "${LOGLEVEL,,}" == "none" ]]; then
-    exec "${s6wrap[@]}" --ignore-stdout --ignore-stderr --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS
+    exec "${s6wrap[@]}" --ignore=stdout --ignore=stderr --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS
 fi


### PR DESCRIPTION
s6wrap was previously silently ignoring unknown command line arguments now it is giving an error