### PR TITLE
mlathub_enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Generally, there is little else to configure, but there are a few parameters tha
 | `MLATHUB_BEAST_REDUCE_OUT_PORT` | TCP port where consolidated MLAT results will be available in Beast format with reduced data rates                                                                                                                                                                                 | `31006`            |
 | `MLATHUB_NET_CONNECTOR`         | (Obsolete, please use `ULTRAFEEDER_CONFIG=mlathub,...` instead.) List of semi-colon (`;`) separated IP or host, port, and protocols where MLATHUB will connect to ingest or send MLAT data. It follows the same syntax as described in the [`READSB_NET_CONNECTOR` syntax section](#alternate-configuration-method-with-readsb_net_connector) above | Unset              |
 | `MLATHUB_DISABLE`               | If set to `true`, the MLATHUB will be disabled even if there are `mlat-client`s running in the container                                                                                                                                                                           | Unset              |
+| `MLATHUB_ENABLE`                | If set to `true`, the MLATHUB will be enabled even if there are no `mlat-client`s running in the container                                                                                                                                                                         | Unset              |
 
 ### Web Gui (`tar1090`) Configuration
 

--- a/rootfs/etc/s6-overlay/scripts/mlathub
+++ b/rootfs/etc/s6-overlay/scripts/mlathub
@@ -29,7 +29,7 @@ if ! [[ "$LOGLEVEL" =~ ^(verbose|error|none)$ ]]; then
     LOGLEVEL="verbose"
 fi
 
-if [[ -z "${MLAT_CONFIG}" ]] && [[ -z "$MLATHUB_NET_CONNECTOR" ]] && [[ ${#MLATHUB_CONF_ARR[@]} == 0 ]]; then
+if [[ -z "${MLAT_CONFIG}" ]] && [[ -z "$MLATHUB_NET_CONNECTOR" ]] && [[ ${#MLATHUB_CONF_ARR[@]} == 0 ]] && ! chk_enabled "${MLATHUB_ENABLE}"; then
     "${s6wrap[@]}" --args echo "No MLAT servers have been defined in MLAT_CONFIG and no external sources have been defined in MLATHUB_NET_CONNECTOR - no need to start MLATHUB"
     exec sleep infinity
 fi


### PR DESCRIPTION
when pushing mlat results into mlat hub, it can be beneficial to have a env var to explicitely enable it even if no mlat-clients are running in ultrafeeder