### PR TITLE
Avoid fast readsb restarts / avoid unnecessary sleep processes

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/adsbx-stats
+++ b/rootfs/etc/s6-overlay/scripts/adsbx-stats
@@ -23,12 +23,14 @@ source /scripts/interpret_ultrafeeder_config
 # Check if ADSBExchange is configured
 if ! grep -i adsbexchange.com <<< "$ULTRAFEEDER_CONFIG" >/dev/null 2>&1; then
     "${s6wrap[@]}" echo "AdsbExchange not configured - no stats package needed"
+    s6-svc -d /run/service/adsbx-stats
     exec sleep infinity
 fi
 
 # Check if ADSBExchange stats are disabled
 if chk_disabled "$ADSBX_STATS" ; then
     "${s6wrap[@]}" echo "AdsbExchange stats disabled"
+    s6-svc -d /run/service/adsbx-stats
     exec sleep infinity
 fi
 
@@ -42,6 +44,7 @@ fi
 if [[ ! -f /usr/local/bin/json-status ]]; then
     if ! curl -sSL -o /usr/local/bin/json-status https://raw.githubusercontent.com/sdr-enthusiasts/docker-adsb-ultrafeeder/main/downloads/adsbexchange-json-status; then
         "${s6wrap[@]}" echo "ERROR: AdsbExchange configured, but cannot download stats package! AdsbExchange will be fed but stats will not be available"
+        s6-svc -d /run/service/adsbx-stats
         exec sleep infinity
     fi
     chmod 755 /usr/local/bin/json-status

--- a/rootfs/etc/s6-overlay/scripts/mlat-client
+++ b/rootfs/etc/s6-overlay/scripts/mlat-client
@@ -42,12 +42,14 @@ declare -A pid_array
 if [[ -z "${MLAT_CONFIG}" ]]
 then
     "${s6wrap[@]}" --args echo "Warning: MLAT_CONFIG not defined - MLAT will be disabled."
+    s6-svc -d /run/service/mlat-client
     exec sleep infinity
 fi
 
 if [[ -z "${MLAT_USER}" ]] && [[ -z "${UUID}" ]]
 then
     "${s6wrap[@]}" --args echo "ERROR: either UUID or MLAT_USER must be defined - MLAT will be disabled."
+    s6-svc -d /run/service/mlat-client
     exec sleep infinity
 fi
 

--- a/rootfs/etc/s6-overlay/scripts/mlathub
+++ b/rootfs/etc/s6-overlay/scripts/mlathub
@@ -31,11 +31,13 @@ fi
 
 if [[ -z "${MLAT_CONFIG}" ]] && [[ -z "$MLATHUB_NET_CONNECTOR" ]] && [[ ${#MLATHUB_CONF_ARR[@]} == 0 ]] && ! chk_enabled "${MLATHUB_ENABLE}"; then
     "${s6wrap[@]}" --args echo "No MLAT servers have been defined in MLAT_CONFIG and no external sources have been defined in MLATHUB_NET_CONNECTOR - no need to start MLATHUB"
+    s6-svc -d /run/service/mlathub
     exec sleep infinity
 fi
 
 if chk_enabled "${MLATHUB_DISABLE}"; then
     "${s6wrap[@]}" --args echo "MLATHUB is disabled."
+    s6-svc -d /run/service/mlathub
     exec sleep infinity
 fi
 

--- a/rootfs/etc/s6-overlay/scripts/readsb
+++ b/rootfs/etc/s6-overlay/scripts/readsb
@@ -364,6 +364,12 @@ if chk_enabled "$PROMETHEUS_ENABLE"; then
     READSB_CMD+=("--write-prom=/run/readsb-prometheus.prom")
 fi
 
+# wait 15 seconds if this is not the first startup
+if [[ $(s6-svdt /run/service/readsb | wc -l) != 0 ]]; then
+    "${s6wrap[@]}" --args echo "delaying restart by 15 seconds"
+    sleep 15
+fi
+
 # shellcheck disable=SC2086
 if [[ "${LOGLEVEL,,}" == "verbose" ]]; then
     exec "${s6wrap[@]}" --args "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_AUTOMATION_ARGS $READSB_EXTRA_ARGS


### PR DESCRIPTION
If the SDR fails, readsb restarts very quickly.
Fix that by sleeping 15 seconds if this is not the first startup of the readsb service.

Avoid having extra sleep processes running by stopping unneeded services