### PR TITLE
fixup adsbx stats UUID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlatclient AS buildimage
 SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 RUN \
     --mount=type=bind,source=./,target=/app/ \
-    apt-get update -q -y && \
-    apt-get install -o Dpkg::Options::="--force-confnew" -y --no-install-recommends -q \
-        build-essential && \
+    # this baseimage has build-essential installed, no need to install it
+    #apt-get update -q -y && \
+    #apt-get install -o Dpkg::Options::="--force-confnew" -y --no-install-recommends -q \
+    #    build-essential && \
     gcc -static /app/downloads/distance-in-meters.c -o /distance -lm -O2
 
 FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest

--- a/downloads/adsbexchange-json-status
+++ b/downloads/adsbexchange-json-status
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# DEPRECATED, see ./rootfs/usr/local/bin/adsbexchange-json-status
+
 #
 # Upload output data from decoder to remote server
 #

--- a/rootfs/etc/s6-overlay/scripts/adsbx-stats
+++ b/rootfs/etc/s6-overlay/scripts/adsbx-stats
@@ -35,28 +35,24 @@ fi
 # prep work:
 mkdir -p /run/adsbexchange-stats
 
-# Install the Stats package:
-if [[ ! -f /etc/default/adsbexchange-stats ]]; then
-    echo -e "UUID_FILE=/run/uuid\nJSON_PATHS=(\"/run/readsb\")" > /etc/default/adsbexchange-stats
-fi
-
 # set the UUID:
-if [[ ! -f /usr/local/share/adsbexchange/adsbx-uuid ]]; then
-    # get UUID from ULTRAFEEDER_CONFIG if it exists
-    for entry in "${READSB_CONF_ARR[@]}"; do
-        if echo "$entry" | grep -q 'adsbexchange.*uuid'; then
-            ADSBX_UUID="$(sed  's|.*adsbexchange.*uuid=\([a-f0-9-]\+\).*|\1|g' <<< "$entry")"
-        fi
-    done
-    ADSBX_UUID="${ADSBX_UUID:-${UUID}}" || true # ...else get it from the UUID param
-    ADSBX_UUID="${ADSBX_UUID:-$(cat /proc/sys/kernel/random/uuid 2>/dev/null)}" || true # ...else generate a random one
-    if [[ -n "$ADSBX_UUID" ]]; then
-        mkdir -p /usr/local/share/adsbexchange
-        echo "$ADSBX_UUID" > /usr/local/share/adsbexchange/adsbx-uuid
-        "${s6wrap[@]}" echo "Using UUID $ADSBX_UUID for AdsbExchange"
-    else
-        "${s6wrap[@]}" echo "WARNING: no UUID can be identified to be used with AdsbExchange; a random one will be generated every time the container is started."
+# get UUID from ULTRAFEEDER_CONFIG if it exists
+for entry in "${READSB_CONF_ARR[@]}"; do
+echo "$entry"
+    if echo "$entry" | grep -q 'adsbexchange.*uuid'; then
+        ADSBX_UUID="$(sed  's|.*adsbexchange.*uuid=\([a-f0-9-]\+\).*|\1|g' <<< "$entry")"
     fi
+done
+
+ADSBX_UUID="${ADSBX_UUID:-${UUID}}" || true # ...else get it from the UUID param
+ADSBX_UUID="${ADSBX_UUID:-$(cat /proc/sys/kernel/random/uuid 2>/dev/null)}" || true # ...else generate a random one
+
+if [[ -n "$ADSBX_UUID" ]]; then
+    # export the variable, it's used by json-status which is started by this script at the very end
+    export ADSBX_UUID
+    "${s6wrap[@]}" echo "Using UUID $ADSBX_UUID for AdsbExchange"
+else
+    "${s6wrap[@]}" echo "WARNING: no UUID can be identified to be used with AdsbExchange; a random one will be generated every time the container is started."
 fi
 
 # wait until readsb is established...

--- a/rootfs/usr/local/bin/adsbexchange-json-status
+++ b/rootfs/usr/local/bin/adsbexchange-json-status
@@ -17,7 +17,7 @@ DNS_IGNORE_LOCAL=1
 
 # List all paths, IN PREFERRED ORDER, separated by a SPACE
 # By default, only use the json from the feed client
-JSON_PATHS=("/run/adsbexchange-feed")
+JSON_PATHS=("/run/readsb")
 
 ######################################################################################################################
 # If you know what you're doing, and you want to override the search path, you can do it easily in
@@ -27,11 +27,6 @@ JSON_PATHS=("/run/adsbexchange-feed")
 # You can enable this old path by setting "USE_OLD_PATH=1", preferrably in /etc/default/adsbexchange-stats
 ######################################################################################################################
 
-# UUID file
-UUID_FILE="/boot/adsbx-uuid"
-if [[ ! -f "$UUID_FILE" ]]; then
-    UUID_FILE="/usr/local/share/adsbexchange/adsbx-uuid"
-fi
 
 # source local overrides (commonly the JSON_PATH, or DNS cache settings)
 if [ -r /etc/default/adsbexchange-stats ]; then
@@ -95,7 +90,7 @@ while [ "x$JSON_DIR" = "x" ]; do
 	fi
 done
 
-UUID=$(cat $UUID_FILE)
+UUID=$ADSBX_UUID
 
 if ! [[ $UUID =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$ ]]; then
     # Data in UUID file is invalid


### PR DESCRIPTION
     fixup adsbx stats UUID

    in cases where UUID and adsbx specific uuids differ, there was a bug of
    UUID_FILE being set to /run/uuid by adsbx-stats script in
    /etc/default/adsbexchange-stats
    the json-status script should read from
    UUID_FILE=/usr/local/share/adsbexchange/adsbx-uuid

    just export ADSBX_UUID in adsbx-stats which then invokes
    adsbexchange-json-status.
    in there use ADSBX_UUID instead of doing the redirect via the UUID file

    cleanup the whole configuration file stuff for adsbx-stats, just
    customize json-status a bit

    also speed up build as build-essential doesn't need to be installed on
    the mlat-client baseimage, it already has it
