### PR TITLE
Update gpsd options to work with USB GPS Mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,7 +896,7 @@ cat << EOM | sudo tee /etc/default/gpsd
 # They need to be read/writeable, either by user gpsd or the group dialout.
 DEVICES="/dev/ttyACM0"
 # Other options you want to pass to gpsd
-GPSD_OPTIONS="-G"
+GPSD_OPTIONS="-G -p"
 # Automatically hot add/remove USB GPS devices via gpsdctl
 USBAUTO="true"
 EOM


### PR DESCRIPTION
The VK164 USB Mouse is used as example in the README and it turns out that gpsd-3.22 (the default in current Debian) is broken with this device (see https://forums.raspberrypi.com/viewtopic.php?t=336887). This adds the workaround to not reconfigure the receiver to the sample script.