### PR TITLE
Disable Grafana JavaScript sanitization to permit iframe graph scripts

### DIFF
--- a/README-grafana.md
+++ b/README-grafana.md
@@ -123,6 +123,10 @@ services:
       - GF_RENDERING_SERVER_URL=http://renderer:8081/render
       - GF_RENDERING_CALLBACK_URL=http://grafana:3000/
       - GF_LOG_FILTERS=rendering:debug
+    # Required for iframe panels, however this has serious security implications - delete the line below if:
+    # 1. You let untrusted users or the public edit your dashboard
+    # 2. You use this Grafana instance for other (non-Ultrafeeder) dashboards
+      - GF_PANELS_DISABLE_SANITIZE_HTML=true
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
A new Grafana instance created from `README-grafana.md` has broken iframe charts. This is due to changes upstream by grafana, specifically that:

1. JavaScirpt is now disabled by default in iframes.
2. iframe rendering has changed and requires changes to the CSS in the iframe tag's Text component.

This PR addresses issue 1 by enabling JavaScript in iframes.

### Security
This has serious security implications, which is addressed in the `docker-compose.yml` comments above the flag. I think it is better in this scenario to enable the flag by default out-of-the-box and warn the user in the plain language when their security posture dictates disabling it.