### PR TITLE
readme: change to pushing mlat results from external containers into …

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,10 @@ Here, `<host>` and `<port>` are mandatory, <return_port> is optional (and can be
 
 ###### Integrate external MLAT return data with Ultrafeeder
 
-Even though MLAT return data received from any MLAT Servers connected directly to Ultrafeeder are automatically integrated with Ultrafeeder, this is not the case if you are using external containers or software to send MLAT data to a MLAT Server. The latter would be the case if you use the FlightAware/PiAware container, the FR24 container, RadarVirtuel container, etc.
+Even though MLAT return data received from any MLAT Servers connected directly to Ultrafeeder are automatically integrated with Ultrafeeder, this is not the case if you are using external containers or software to send MLAT data to a MLAT Server. The latter would be the case if you use the FlightAware/PiAware container, RadarVirtuel container, etc. (FR24 does not provide MLAT results)
 
-In this case, you can use the `mlathub` construct to collect MLAT return data from these external MLAT clients, and integrate them with Ultrafeeder data. You can further configure this MLAT Hub as described in the section [Configuring the built-in MLAT Hub](#configuring-the-built-in-mlat-hub).
+It is recommended to push the MLAT results from those containers back into ultrafeeder. (for example in piaware containter: MLAT_RESULTS_BEASTHOST=ultrafeeder)
+Or you can use the `mlathub` construct to collect MLAT return data from these external MLAT clients, and integrate them with Ultrafeeder data. You can further configure this MLAT Hub as described in the section [Configuring the built-in MLAT Hub](#configuring-the-built-in-mlat-hub).
 
 ```yaml
 - ULTRAFEEDER_CONFIG=mlathub,<host>,<port>,<protocol>[,uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX][,silent_fail][,<extra-arguments>]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,10 +54,6 @@ services:
         mlat,feed.theairtraffic.com,31090,39004;
         mlat,skyfeed.hpradar.com,31090,39005;
         mlat,dati.flyitalyadsb.com,30100,39007;
-        mlathub,piaware,30105,beast_in;
-        mlathub,rbfeeder,30105,beast_in;
-        mlathub,radarvirtuel,30105,beast_in;
-        mlathub,planewatch,30105,beast_in
       # If you really want to feed ADSBExchange, you can do so by adding this above:
       #        adsb,feed1.adsbexchange.com,30004,beast_reduce_plus_out,uuid=${ADSBX_UUID};
       #        mlat,feed.adsbexchange.com,31090,39008,uuid=${ADSBX_UUID}


### PR DESCRIPTION
…ultrafeeder

this avoids errors in the log when those containers are not used (false positive errors are problematic as they obscure real errors)