### PR TITLE
ci: fix persistent hadolint failure in Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,16 +42,6 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   deploy:
     name: Deploy without telegraf
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@d99ce7f631ca56901a4aecca25d5c6e4b0a7e2f1 # main

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest
 
 LABEL org.opencontainers.image.source="https://github.com/sdr-enthusiasts/docker-adsb-ultrafeeder"
 
+# DL3064 matches on the variable *name* containing "PRIVATE", regardless of its
+# value. PRIVATE_MLAT is a boolean toggle for the mlat-client privacy flag, not
+# a credential, so this is a false positive.
+# hadolint ignore=DL3064
 ENV \
     PRIVATE_MLAT="false" \
     MLAT_INPUT_TYPE="auto"


### PR DESCRIPTION
## Problem

Every `Deploy` run since 2026-08-01 has shown a red X, even though the image built and pushed successfully. The only failing job was `Run hadolint against docker files`:

```text
failure  Run hadolint against docker files
success  Deploy without telegraf / Prepare workflow environment
success  Deploy with telegraf and healthcheck / Prepare workflow environment
success  Deploy with telegraf and healthcheck / Build (manifest) (ubuntu-24.04-arm, arm64, linux/arm64, true)
success  Deploy with telegraf and healthcheck / Build (manifest) (ubuntu-24.04-arm, arm32, linux/arm/v7, true)
success  Deploy with telegraf and healthcheck / Build (manifest) (ubuntu-latest, linux/amd64, true)
success  Deploy without telegraf / Build (manifest) (ubuntu-latest, linux/amd64, true)
success  Deploy without telegraf / Build (manifest) (ubuntu-24.04-arm, arm64, linux/arm64, true)
success  Deploy without telegraf / Build (manifest) (ubuntu-24.04-arm, arm32, linux/arm/v7, true)
success  Deploy with telegraf and healthcheck / merge
success  Deploy without telegraf / merge
```

This also puts `docker-baseimage` at risk: its `monitor_downstream_builds` job explicitly watches the `tar1090 -> ultrafeeder` chain (`TAR1090_ULTRAFEEDER_REPO`) and does `exit 1` if any watched run failed, so a red run here fails the base image's own `Deploy` on the next fan-out.

## Root cause

The job pulled unpinned `hadolint/hadolint:latest`, so it silently adopted upstream rule changes. hadolint **v2.15.0** added `DL3064`, which flags `ARG`/`ENV` assignments whose name suggests sensitive data. The `Deploy` history brackets the release exactly:

| Run | Time (UTC) | hadolint job |
|--------------------|------------------------|---------|
| 30655885396 | 2026-07-27T14:51:14Z | success |
| *v2.15.0 released* | *2026-07-30T13:39:01Z* | |
| 30736429301 | 2026-08-01T13:42:54Z | failure |
| 30800230752 | 2026-08-02T21:40:19Z | failure |
| 30825010246 | 2026-08-03T14:55:26Z | failure |

Nothing in the Dockerfile changed. Reproduced across versions:

```console
$ printf 'FROM debian:trixie-slim\nENV PRIVATE_MLAT="false"\n' > Dockerfile.d64

$ hadolint Dockerfile.d64                    # 2.14.0, the flake.lock pin
rc=0

$ docker run --rm -i --entrypoint hadolint hadolint/hadolint:v2.15.0 - < Dockerfile.d64
-:2 DL3064 warning: Potentially sensitive data should not be used in the `ARG` or `ENV` commands
rc=1
```

`DL3064` matches on the variable **name**, regardless of its value or whether the variable is ever read:

```text
ENV PRIVATE="x"      -> DL3064
ENV MY_SECRET="x"    -> DL3064
ENV MY_PASSWORD="x"  -> DL3064
ENV MY_TOKEN="x"     -> DL3064
ENV MY_KEY="x"       -> clean
```

`PRIVATE_MLAT` is a boolean toggle for the mlat-client privacy flag, not a credential, so this is a false positive.

## Changes

**`chore: suppress DL3064 false positive on PRIVATE_MLAT`** — an inline ignore, rather than adding `DL3064` to the shared pre-commit ruleset, which would disable a legitimate credential check across every repo:

```diff
+# DL3064 matches on the variable *name* containing "PRIVATE", regardless of its
+# value. PRIVATE_MLAT is a boolean toggle for the mlat-client privacy flag, not
+# a credential, so this is a false positive.
+# hadolint ignore=DL3064
 ENV \
     PRIVATE_MLAT="false" \
     MLAT_INPUT_TYPE="auto"
```

Comment-only, so the built image is unchanged.

**`ci: drop redundant hadolint job from deploy workflow`** — linting does not belong in the deploy path, and `lint.yaml` already runs hadolint over this Dockerfile on every PR via pre-commit, against a version pinned through `flake.lock` rather than a floating tag. Coverage is unchanged.

The job was standalone with no `needs:` dependents, so removing it does not affect the rest of the workflow. Remaining jobs:

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- deploy
- deploy_with_telegraf
```

## Verification

Coverage is preserved — the generated pre-commit config carries a `hadolint` hook whose file filter matches this Dockerfile:

```console
$ grep -o '"id": "hadolint"' .pre-commit-config.yaml
"id": "hadolint"
$ grep -o '/nix/store/[^"]*hadolint-[0-9.]*/bin/hadolint' .pre-commit-config.yaml
/nix/store/gg0zllfabq395d8i6vyn3ljbavfh4d1p-hadolint-2.14.0/bin/hadolint
$ grep -o '"files": "[^"]*Dockerfile[^"]*"' .pre-commit-config.yaml
"files": "(^|/)Dockerfile.*+$|\\.Dockerfile$"
```

Checked at **each commit individually**, not just at the tip, so `git bisect` stays usable:

```text
0b0cb980  hadolint 2.14.0:rc=0  2.15.1:rc=0  chore: suppress DL3064 false positive on PRIVATE_MLAT
1cd9d011  hadolint 2.14.0:rc=0  2.15.1:rc=0  ci: drop redundant hadolint job from deploy workflow
```

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped, including `hadolint`, `check-github-workflows` and `check-yaml`
- No hooks bypassed; no `--no-verify`
- No image rebuild required — the Dockerfile delta is a comment, which cannot alter the built image

## Note for follow-up (not addressed here)

Independently of the lint fix, `PRIVATE_MLAT` appears to be dead config in this repo:

- Nothing in the published image reads it — grepped `/etc /usr /opt /var /command /package …` in `ghcr.io/sdr-enthusiasts/docker-adsb-ultrafeeder:latest`, zero consumers. By contrast `MLAT_INPUT_TYPE` resolves to `/etc/s6-overlay/scripts/mlat-client`.
- It dates to `ad94959 initial commit` and has never been modified; the string `privacy` has never appeared in this repo's history.
- It is not documented in this README, ADSB-Docs, gitbook-adsb-guide, adsb-compose or docker-install.
- The working, documented implementation lives in `docker-radarvirtuel` (`rootfs/etc/s6-overlay/scripts/mlat-client:72` → `MLAT_PARAM+=("--privacy")`, `README.md:163`).

So the image currently advertises a privacy knob in `docker inspect` that does nothing. Worth a separate issue to either wire it up for parity with radarvirtuel or remove it. Deliberately left as-is in this PR.
